### PR TITLE
Fix docs to reference the right major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Docs to reference the right major version.
+
 ## [2.0.0] - 2020-10-08
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ In your theme's `manifest.json` file, add the Product Highlights app as a depend
 
 ```diff
  "dependencies": {
-+  "vtex.product-highlights": "1.x"
++  "vtex.product-highlights": "2.x"
 }
 ```
 
@@ -43,7 +43,7 @@ According to your desire, copy one of the examples stated below and paste it in 
 
 ```json
 {
-  "vtex.product-highlights@1.x:product-highlights": {
+  "vtex.product-highlights@2.x:product-highlights": {
     "children": ["product-highlight-text"]
   },
   "product-highlight-text": {
@@ -58,7 +58,7 @@ According to your desire, copy one of the examples stated below and paste it in 
 
 ```jsonc
 {
-  "vtex.product-highlights@1.x:product-highlights": {
+  "vtex.product-highlights@2.x:product-highlights": {
     "children": ["product-highlights-wrapper"]
   },
   "product-highlights-wrapper": {
@@ -79,7 +79,7 @@ According to your desire, copy one of the examples stated below and paste it in 
 
 ```jsonc
 {
-  "vtex.product-highlights@1.x:product-highlights": {
+  "vtex.product-highlights@2.x:product-highlights": {
     "props": {
       "type": "teaser",
       "filter": {


### PR DESCRIPTION
#### What problem is this solving?

Missed some docs changes on https://github.com/vtex-apps/product-highlights/pull/4

