### PR TITLE
Check if `filterHighlights` exists before using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Check if highlightNames exists on filter before using it
 
 ## [2.2.2] - 2022-02-04
 ### Fixed:

--- a/react/ProductHighlights.tsx
+++ b/react/ProductHighlights.tsx
@@ -36,7 +36,7 @@ interface ProductHighlightContextProviderProps {
 
 function createFilterHighlight(filter: Filter) {
   return function filterHighlight(highlight: Highlight) {
-    const hasHighlight = filter.highlightNames.includes(highlight.name)
+    const hasHighlight = filter.highlightNames?.includes(highlight.name)
 
     if (
       (filter.type === 'hide' && hasHighlight) ||


### PR DESCRIPTION
#### What problem is this solving?

As stated in this [slack thread](https://vtex.slack.com/archives/C01PRGM0WG1/p1660587445852829), some products were not showing up on the screen. They were missing because `filter.highlightNames` was returning `undefined` and the code was using it result without checking for it's presence

#### How to test it?

Go to https://danzan--storecomponents.myvtex.com/. See that all 4 products show up on the homepage. See that at https://storecomponents.myvtex.com/ only two products are displayed.

#### Screenshots or example usage:

**Before:**
![image](https://user-images.githubusercontent.com/8497187/184696384-68ef8e3d-d4a5-42f6-95a3-9e53f5d4bbee.png)

**After:**
![image](https://user-images.githubusercontent.com/8497187/184696432-11fec39c-ea92-46ac-9cc0-c5bcd9f22612.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
