### PR TITLE
Fix: Make ProductHighlights resilient to empty filters from Site Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ProductHighlights resilient to empty filters from Site Editor
+
 ## [2.3.1] - 2023-06-30
 
 ### Fixed

--- a/react/ProductHighlights.tsx
+++ b/react/ProductHighlights.tsx
@@ -36,8 +36,7 @@ interface ProductHighlightContextProviderProps {
 
 function createFilterHighlight(filter: Filter) {
   return function filterHighlight(highlight: Highlight) {
-    const namesToFilter = filter.highlightNames ?? [] 
-    const hasHighlight = namesToFilter.includes(highlight.name)
+    const hasHighlight = filter.highlightNames?.includes(highlight.name)
 
     if (
       (filter.type === 'hide' && hasHighlight) ||

--- a/react/ProductHighlights.tsx
+++ b/react/ProductHighlights.tsx
@@ -36,7 +36,8 @@ interface ProductHighlightContextProviderProps {
 
 function createFilterHighlight(filter: Filter) {
   return function filterHighlight(highlight: Highlight) {
-    const hasHighlight = filter.highlightNames.includes(highlight.name)
+    const namesToFilter = filter.highlightNames ?? [] 
+    const hasHighlight = namesToFilter.includes(highlight.name)
 
     if (
       (filter.type === 'hide' && hasHighlight) ||


### PR DESCRIPTION
#### What problem is this solving?

A production error was identified that was breaking component rendering on some shelves. The reported error was: TypeError: Cannot read properties of undefined (reading 'includes').

The root cause of the issue is that the Site Editor, under certain conditions, saves the filter prop's configuration as an empty object ({}), which results in filter.highlightNames being undefined. This caused a crash inside the createFilterHighlight function when attempting to call the .includes() method.

Content from site editor:
<img width="688" height="565" alt="image" src="https://github.com/user-attachments/assets/dc06c36d-7c97-471e-8a47-d0b1fe4fe0e2" />

Workspace where the error occurs, for it to happen, the products must have entries on the clusterHighlights field:
<img width="1509" height="786" alt="image" src="https://github.com/user-attachments/assets/fae5d8ca-2761-48c2-8bae-1438b5b23a5b" />

To fix the issue and make the component more robust, the createFilterHighlight function was modified to handle a missing highlightNames property safely.

The nullish coalescing operator (??) was used to provide an empty array ([]) as a fallback value in case filter.highlightNames is null or undefined.

<img width="1509" height="786" alt="image" src="https://github.com/user-attachments/assets/e8dda5df-a3cd-40aa-aada-6853a100ecf3" />

This targeted change fixes the error directly at its source, ensuring the filter logic never crashes due to an incomplete filter object.

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExYW01eGM4Zzhudno5bHQ3MGtpeG5hYXl5d3huaW1seTA5ejl6dW11YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ez1QgBv3LAzwcYiGDK/giphy.gif)
